### PR TITLE
Update requirements.txt: sklearn -> scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sklearn
+scikit-learn
 matplotlib
 h5py
 pandas


### PR DESCRIPTION
Hello!

I was just installing miniML and ran into the issue that `sklearn` is no longer a valid name with which to install the Scikit-learn package. I have updated `requirements.txt` to fix this issue.