### PR TITLE
Remove pandas dependency and refactor CSV export to native implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In this repository, we provide documentation, pre-trained models, and Python cod
 
 ### 💻 INSTALLATION
 
-To use miniML, clone the GitHub Repository and install, e.g. using pip. miniML has been tested with Python 3.9 and 3.10. The Python dependencies are: sklearn, matplotlib, h5py, pandas, numpy, scipy, tensorflow, pyabf, ruptures. 
+To use miniML, clone the GitHub Repository and install, e.g. using pip. miniML has been tested with Python 3.9 and 3.10. The Python dependencies are: sklearn, matplotlib, h5py, numpy, scipy, tensorflow, pyabf, ruptures.
 
 For the GUI, PyQt5, qt-material, and pyqtgraph are also required.
 

--- a/docs/general/installation.md
+++ b/docs/general/installation.md
@@ -12,7 +12,6 @@ The Python dependencies for miniML are:
 - sklearn
 - matplotlib
 - h5py
-- pandas
 - numpy
 - scipy
 - tensorflow

--- a/miniml/miniML.py
+++ b/miniml/miniML.py
@@ -4,7 +4,6 @@ import h5py
 import matplotlib.pyplot as plt
 import tensorflow as tf
 import os
-import pandas as pd
 import pickle as pkl
 from pathlib import Path
 from scipy import signal
@@ -1409,11 +1408,20 @@ class EventDetection():
         
         column_names = [f'event_{i}' for i in range(len(self.event_locations))]
 
-        individual = pd.DataFrame(individual, index=['location', 'score', 'amplitude', 'charge', 'risetime', 'decaytime', 'halfwidth', 'interval'], columns=column_names)
-        avgs = pd.DataFrame(avgs, index=['amplitude mean', 'amplitude std', 'amplitude median', 'charge mean', 'risetime mean', 'decaytime mean', 'halfwidth mean', 'tau_avg', 'frequency', 'iei mean'], columns=['value'])
-        
-        individual.to_csv(f'{filename}_individual.csv')
-        avgs.to_csv(f'{filename}_avgs.csv', header=False)
+        import csv
+        row_labels_ind = ['location', 'score', 'amplitude', 'charge', 'risetime', 'decaytime', 'halfwidth', 'interval']
+        with open(f'{filename}_individual.csv', 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow([''] + column_names)
+            for label, row_data in zip(row_labels_ind, individual):
+                writer.writerow([label] + list(row_data))
+
+        row_labels_avg = ['amplitude mean', 'amplitude std', 'amplitude median', 'charge mean', 'risetime mean', 'decaytime mean', 'halfwidth mean', 'tau_avg', 'frequency', 'iei mean']
+        with open(f'{filename}_avgs.csv', 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            for label, val in zip(row_labels_avg, avgs):
+                writer.writerow([label, val])
+
         print(f'events saved to {filename}_avgs.csv and {filename}_individual.csv')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "scikit-learn==1.5.1",
     "matplotlib==3.6.3",
     "h5py==3.11.0",
-    "pandas==1.5.3",
     "numpy<2.0.0",
     "scipy==1.11.1",
     "tensorflow>=2.14.0,<2.16.0",

--- a/tests/test_miniML_functions.py
+++ b/tests/test_miniML_functions.py
@@ -256,5 +256,81 @@ class TestEventDetectionDeleteEvents(unittest.TestCase):
         # Verify blacklisted attribute singular_event_indices was not deleted from
         np.testing.assert_array_equal(detection.singular_event_indices, np.array([0, 1, 2]))
 
+class TestEventDetectionSaveToCSV(unittest.TestCase):
+    def test_save_to_csv_correctness(self):
+        import tempfile
+        import csv
+        from miniml.miniML import MiniTrace, EventDetection
+        from unittest.mock import MagicMock
+
+        trace = MiniTrace(data=np.zeros(1000), sampling_interval=0.0001)
+        detection = EventDetection(data=trace, window_size=600)
+
+        detection.event_locations = np.array([100, 200])
+        detection.event_scores = np.array([0.9, 0.95])
+        detection.interevent_intervals = np.array([0.1, 0.15])
+
+        # Create a mock for event_stats
+        mock_stats = MagicMock()
+        mock_stats.amplitudes = np.array([-10.0, -12.0])
+        mock_stats.charges = np.array([-1.0, -1.2])
+        mock_stats.risetimes = np.array([0.001, 0.002])
+        mock_stats.halfdecays = np.array([0.005, 0.006])
+        mock_stats.halfwidths = np.array([0.002, 0.003])
+
+        # mock mean, std, median to return some fixed values
+        mock_stats.mean = lambda x: np.mean(x)
+        mock_stats.std = lambda x: np.std(x)
+        mock_stats.median = lambda x: np.median(x)
+        mock_stats.avg_tau_decay = 0.005
+        mock_stats.frequency = lambda: 2.0
+
+        detection.event_stats = mock_stats
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = os.path.join(tmpdir, "test_out")
+            detection.save_to_csv(filepath)
+
+            # Now verify individual csv exists and is correct
+            ind_path = f"{filepath}_individual.csv"
+            avg_path = f"{filepath}_avgs.csv"
+
+            self.assertTrue(os.path.exists(ind_path))
+            self.assertTrue(os.path.exists(avg_path))
+
+            # Read individual csv
+            with open(ind_path, 'r', newline='', encoding='utf-8') as f:
+                reader = csv.reader(f)
+                rows = list(reader)
+
+            self.assertEqual(rows[0], ['', 'event_0', 'event_1'])
+            self.assertEqual(rows[1], ['location', '100.0', '200.0'])
+            self.assertEqual(rows[2], ['score', '0.9', '0.95'])
+            self.assertEqual(rows[3], ['amplitude', '-10.0', '-12.0'])
+
+            # Read avgs csv
+            with open(avg_path, 'r', newline='', encoding='utf-8') as f:
+                reader = csv.reader(f)
+                avg_rows = list(reader)
+
+            # ['amplitude mean', '-11.0'] etc
+            expected_avg_rows = [
+                ['amplitude mean', '-11.0'],
+                ['amplitude std', '1.0'],
+                ['amplitude median', '-11.0'],
+                ['charge mean', '-1.1'],
+                ['risetime mean', '0.0015'],
+                ['decaytime mean', '0.0055'],
+                ['halfwidth mean', '0.0025'],
+                ['tau_avg', '0.005'],
+                ['frequency', '2.0'],
+                ['iei mean', '0.125']
+            ]
+
+            # Compare rows
+            for actual, expected in zip(avg_rows, expected_avg_rows):
+                self.assertEqual(actual[0], expected[0])
+                self.assertAlmostEqual(float(actual[1]), float(expected[1]), places=5)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Removed the pandas dependency since its only usage in the repository was for saving data to CSV. The CSV export functionality has been completely rewritten using Python's built-in `csv` module, retaining identical output structure. I also updated pyproject.toml, README.md, and docs/general/installation.md, and added extensive unit tests to prevent regressions.

---
*PR created automatically by Jules for task [13263220702130248102](https://jules.google.com/task/13263220702130248102) started by @delvendahl*